### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/kruiz780/b0040787-3008-4383-93b2-eac9edfd4f0a/438592af-3b4c-4aed-b602-16f60cb73ac6/_apis/work/boardbadge/c38a9390-79fa-4016-a3bb-0f82af06ede1)](https://dev.azure.com/kruiz780/b0040787-3008-4383-93b2-eac9edfd4f0a/_boards/board/t/438592af-3b4c-4aed-b602-16f60cb73ac6/Microsoft.RequirementCategory)
 # Introduction 
 TODO: Give a short introduction of your project. Let this section explain the objectives or the motivation behind this project. 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#16](https://dev.azure.com/kruiz780/b0040787-3008-4383-93b2-eac9edfd4f0a/_workitems/edit/16). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.